### PR TITLE
custom_wide: make menu button visible on followed profiles

### DIFF
--- a/themes/custom_wide.scss
+++ b/themes/custom_wide.scss
@@ -26,3 +26,7 @@
 .status__content a {
   color: #49a0de;
 }
+
+.button--with-bell {
+    min-width: 0 !important;
+}


### PR DESCRIPTION
The chaos-social-wide theme has less horizontal space in the columns, so the menu button on followed profiles is pushed off the screen by the larger "Unfollow" button and the bell button beside it. Remove the min-width constraint on the Unfollow button, whose text will be broken onto to lines, to fix this.

Before:
![](https://user-images.githubusercontent.com/192014/159990941-f562eafc-b0c7-4b67-a798-70029bb97b1d.png)
After:
![](https://user-images.githubusercontent.com/192014/159990944-305b7523-4cca-426b-b254-2b642bd4524d.png)